### PR TITLE
Fix issue where ReflectionListener could not access private methods

### DIFF
--- a/src/com/esotericsoftware/kryonet/Listener.java
+++ b/src/com/esotericsoftware/kryonet/Listener.java
@@ -65,6 +65,7 @@ public class Listener {
 				if (classToMethod.containsKey(type)) return; // Only fail on the first attempt to find the method.
 				try {
 					method = getClass().getMethod("received", new Class[] {Connection.class, type});
+					method.setAccessible(true);
 				} catch (SecurityException ex) {
 					if (ERROR) error("kryonet", "Unable to access method: received(Connection, " + type.getName() + ")", ex);
 					return;


### PR DESCRIPTION
`ReflectionListener` can currently not access non-visible methods, including public methods declared in anonymous inner classes. This pull request fixes that problem by inserting a call to `Method.setAccessible(true)` after retrieving the method.