### PR TITLE
Added error tracking to Connection

### DIFF
--- a/src/com/esotericsoftware/kryonet/Client.java
+++ b/src/com/esotericsoftware/kryonet/Client.java
@@ -368,6 +368,7 @@ public class Client extends Connection implements EndPoint {
 				}
 				close();
 			} catch (KryoNetException ex) {
+				lastProtocolError = ex;
 				if (ERROR) {
 					if (isConnected)
 						error("kryonet", "Error updating connection: " + this, ex);

--- a/src/com/esotericsoftware/kryonet/Connection.java
+++ b/src/com/esotericsoftware/kryonet/Connection.java
@@ -49,6 +49,7 @@ public class Connection {
 	private long lastPingSendTime;
 	private int returnTripTime;
 	volatile boolean isConnected;
+	volatile KryoNetException lastProtocolError;
 
 	protected Connection () {
 	}
@@ -67,6 +68,15 @@ public class Connection {
 	public boolean isConnected () {
 		return isConnected;
 	}
+	
+   /**
+    * Returns the last protocol error that occured on the connection.
+    * 
+    * @return The last protocol error or null if none error occured.
+    */
+   public KryoNetException getLastProtocolError() {
+      return lastProtocolError;
+   }
 
 	/** Sends the object over the network using TCP.
 	 * @return The number of bytes sent.


### PR DESCRIPTION
Previously, there was no easy way to know in the code why a connection was closed since no information except a connection closed event was given.

This gives the last KryoNetException that occured in the update thread, useful for debugging protocol error like a class not found.